### PR TITLE
Support sources fallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,12 +33,16 @@ module.exports = function(tilelive, options) {
 
     // TODO pass scale
     return async.reduce(sourceUris, [], function(sources, uri, next) {
-      tilelive.load(uri, function(err, source) {
-        if (!err) sources.push({ uri: uri, source: source });
+      return tilelive.load(uri, function(err, source) {
+        if (!err) {
+          sources.push({ uri: uri, source: source });
+        }
         return next(null, sources);
       })
     }, function(err, sources) {
-      if (souces.length === 0) return callback(new Error("Not found any valid sources");
+      if (sources.length === 0) {
+        return callback(new Error("Not found any valid sources");
+      }
       
       return async.map(sources, function(src, next) {
         return src.source.getInfo(next);
@@ -52,7 +56,7 @@ module.exports = function(tilelive, options) {
 
         return callback(null, self);
       });
-    });   
+    });
   };
 
   // TODO allow custom headers (User-Agent, X-Forwarded-For) to be passed

--- a/index.js
+++ b/index.js
@@ -32,24 +32,27 @@ module.exports = function(tilelive, options) {
     }
 
     // TODO pass scale
-    return async.map(sourceUris, async.apply(tilelive.load), function(err, sources) {
-      if (err) {
-        return callback(err);
-      }
-
+    return async.reduce(sourceUris, [], function(sources, uri, next) {
+      tilelive.load(uri, function(err, source) {
+        if (!err) sources.push({ uri: uri, source: source });
+        return next(null, sources);
+      })
+    }, function(err, sources) {
+      if (souces.length === 0) return callback(new Error("Not found any valid sources");
+      
       return async.map(sources, function(src, next) {
-        return src.getInfo(next);
+        return src.source.getInfo(next);
       }, function(err, info) {
-        self.sources = sourceUris.map(function(uri, i) {
+        self.sources = sources.map(function(source, i) {
           return {
             info: info[i],
-            uri: uri
+            uri: source.uri
           };
         });
 
         return callback(null, self);
       });
-    });
+    });   
   };
 
   // TODO allow custom headers (User-Agent, X-Forwarded-For) to be passed

--- a/index.js
+++ b/index.js
@@ -37,13 +37,14 @@ module.exports = function(tilelive, options) {
         if (!err) {
           sources.push({ uri: uri, source: source });
         }
+
         return next(null, sources);
       })
     }, function(err, sources) {
       if (sources.length === 0) {
-        return callback(new Error("Not found any valid sources");
+        return callback(new Error("Did not find any valid sources");
       }
-      
+
       return async.map(sources, function(src, next) {
         return src.source.getInfo(next);
       }, function(err, info) {


### PR DESCRIPTION
When merge multiple sources, do not throw errors if any sources are invalid.
For example, I have `src1`, `src2`, `src3`, and `src2` is invalid. I should get `src1+src3` instead of failed